### PR TITLE
Dry'd up subgraph and fixed edge properties in subgraph

### DIFF
--- a/lib/dag/vertex.rb
+++ b/lib/dag/vertex.rb
@@ -39,7 +39,7 @@ class DAG
     #
     def has_path_to?(other)
       raise ArgumentError.new('You must supply a vertex in this DAG') unless
-        other && Vertex === other && other.dag == self.dag
+        is_vertex_in_my_dag?(other)
       successors.include?(other) || successors.any? {|v| v.has_path_to?(other) }
     end
 
@@ -54,7 +54,7 @@ class DAG
     #
     def has_ancestor?(other)
       raise ArgumentError.new('You must supply a vertex in this DAG') unless
-        other && Vertex === other && other.dag == self.dag
+        is_vertex_in_my_dag?(other)
       predecessors.include?(other) || predecessors.any? {|v| v.has_ancestor?(other) }
     end
 
@@ -91,6 +91,11 @@ class DAG
       return result_set
     end
 
+    private
+
+    def is_vertex_in_my_dag?(v)
+      v.kind_of?(Vertex) and v.dag == self.dag
+    end
   end
 
 end

--- a/spec/lib/dag_spec.rb
+++ b/spec/lib/dag_spec.rb
@@ -140,7 +140,7 @@ describe DAG do
     let(:joe) { subject.add_vertex(name: "joe") }
     let(:bob) { subject.add_vertex(name: "bob") }
     let(:jane) { subject.add_vertex(name: "jane") }
-    let!(:e1) { subject.add_edge(origin: joe, destination: bob) }
+    let!(:e1) { subject.add_edge(origin: joe, destination: bob, properties: {name: "father of"} ) }
     let!(:e2) { subject.add_edge(origin: joe, destination: jane) }
     let!(:e3) { subject.add_edge(origin: bob, destination: jane) }
 
@@ -184,6 +184,8 @@ describe DAG do
         subgraph = subject.subgraph([bob,],[bob,])
         expect(Set.new(subgraph.vertices.map(&:my_name))).to eq(Set.new(["bob","jane","joe"]))
         expect(subgraph.edges.length).to eq(2)
+        expect(subgraph.edges[0].properties).to eq({name: "father of"})
+        expect(subgraph.edges[1].properties).to eq({})
       end
 
     end


### PR DESCRIPTION
Cleanup work on subgraph and edge properties.
- Simplify the subgraph method and reduce the amount of repetition.
- Add the edge properties to subgraph edges.
