### PR TITLE
Render pretty dag pictures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     dag (0.0.4)
+      ruby-graphviz
 
 GEM
   remote: https://rubygems.org/
@@ -20,6 +21,7 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    ruby-graphviz (1.2.1)
 
 PLATFORMS
   ruby

--- a/dag.gemspec
+++ b/dag.gemspec
@@ -8,6 +8,8 @@ Gem::Specification.new do |s|
   s.email       = 'kevin@rutherford-software.com'
   s.homepage    = 'http://github.com/kevinrutherford/dag'
 
+  s.add_dependency "ruby-graphviz"
+
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'rspec', '~> 3'
 

--- a/lib/dag.rb
+++ b/lib/dag.rb
@@ -1,4 +1,5 @@
 require_relative 'dag/vertex'
+require_relative 'dag/dag_presenter'
 
 class DAG
 
@@ -82,6 +83,32 @@ class DAG
     return result
   end
 
+  def render(presenter, args=[])
+    # Given a presenter class which implements DagPresenter transform the modeled information
+    raise ArgumentError,
+      "Unknown presenter class: #{presenter} - must inherit from DagPresenter" unless
+        presenter < DagPresenter
+
+    presentation = presenter.new(*args)
+
+    vertex_mapping = {}
+    # Holds context for processing edges
+
+    vertices.each do |v|
+      vertex_mapping[v] = presentation.add_vertex(v)
+    end
+
+    edges.each do |e|
+      presentation.add_edge(
+          vertex_mapping[e.origin],
+          vertex_mapping[e.destination],
+          e
+        )
+    end
+
+    return presentation
+  end
+
   private
 
   def is_my_vertex?(v)
@@ -89,6 +116,7 @@ class DAG
     #puts "Verts dag is self #{v.dag == self}"
     v.kind_of?(Vertex) and v.dag == self
   end
+
 
 end
 

--- a/lib/dag/dag_presenter.rb
+++ b/lib/dag/dag_presenter.rb
@@ -1,0 +1,16 @@
+require 'graphviz'
+class DagPresenter
+
+  def add_vertex(v)
+    fail NotImplementedError, "#{self.class} must implement add_vertex"
+  end
+
+  def add_edge(presented_from,presented_to, e)
+    fail NotImplementedError, "#{self.class} must implement add_edge"
+  end
+
+  def present(opts={})
+    fail NotImplementedError, "#{self.class} must implement present"
+  end
+
+end

--- a/lib/dag/graphviz_presenter.rb
+++ b/lib/dag/graphviz_presenter.rb
@@ -1,0 +1,45 @@
+require 'graphviz'
+require 'dag/dag_presenter'
+class GraphVizPresenter < DagPresenter
+  # Extenisble class implementing DagPresenter
+  attr_reader :graph
+  class << self; attr_accessor :vertex_presenter_blk, :edge_presenter_blk end
+
+  # Easily inherit from this class and over the presenter blocks.
+  self.vertex_presenter_blk = proc do |v|
+    {
+      shape: 'record',
+      #label: "{Vertex}",
+      color: 'black',
+      fillcolor: 'white',
+      style: 'filled',
+    }
+  end
+
+  self.edge_presenter_blk = proc do |e|
+    {
+      dir: 'forward',
+      color: 'blue'
+    }
+  end
+
+  def initialize
+    @graph = GraphViz.new(:G, :type => :digraph)
+    @vcounter=-1
+  end
+
+  def add_vertex(v)
+    @vcounter +=1
+    graph.add_node(@vcounter.to_s, self.class.vertex_presenter_blk.call(v))
+  end
+
+  def add_edge(from,to,e)
+    graph.add_edge(from,to,self.class.edge_presenter_blk.call(e))
+  end
+
+  def present(opts={})
+    @graph.output(**opts)
+  end
+
+
+end

--- a/lib/dag/vertex.rb
+++ b/lib/dag/vertex.rb
@@ -39,7 +39,7 @@ class DAG
     #
     def has_path_to?(other)
       raise ArgumentError.new('You must supply a vertex in this DAG') unless
-        other && Vertex === other && other.dag == self.dag
+        is_vertex_in_my_dag?(other)
       successors.include?(other) || successors.any? {|v| v.has_path_to?(other) }
     end
 
@@ -54,7 +54,7 @@ class DAG
     #
     def has_ancestor?(other)
       raise ArgumentError.new('You must supply a vertex in this DAG') unless
-        other && Vertex === other && other.dag == self.dag
+        is_vertex_in_my_dag?(other)
       predecessors.include?(other) || predecessors.any? {|v| v.has_ancestor?(other) }
     end
 
@@ -91,6 +91,11 @@ class DAG
       return result_set
     end
 
+    private
+
+    def is_vertex_in_my_dag?(v)
+      v.kind_of?(Vertex) and v.dag == self.dag
+    end
   end
 
 end

--- a/spec/lib/dag_spec.rb
+++ b/spec/lib/dag_spec.rb
@@ -140,7 +140,7 @@ describe DAG do
     let(:joe) { subject.add_vertex(name: "joe") }
     let(:bob) { subject.add_vertex(name: "bob") }
     let(:jane) { subject.add_vertex(name: "jane") }
-    let!(:e1) { subject.add_edge(origin: joe, destination: bob) }
+    let!(:e1) { subject.add_edge(origin: joe, destination: bob, properties: {name: "father of"} ) }
     let!(:e2) { subject.add_edge(origin: joe, destination: jane) }
     let!(:e3) { subject.add_edge(origin: bob, destination: jane) }
 
@@ -184,6 +184,8 @@ describe DAG do
         subgraph = subject.subgraph([bob,],[bob,])
         expect(Set.new(subgraph.vertices.map(&:my_name))).to eq(Set.new(["bob","jane","joe"]))
         expect(subgraph.edges.length).to eq(2)
+        expect(subgraph.edges[0].properties).to eq({name: "father of"})
+        expect(subgraph.edges[1].properties).to eq({})
       end
 
     end


### PR DESCRIPTION
Added hooks to builder presenters.
This PR includes an example graphviz based renderer. It is easily extensible for particular use cases so good to include but it means that this gem now requires graphviz.

It could alternatively be packaged separately with just the render method and the dag presenter base class included in the dag gem. The intent is very much a plugin style tool.
