### PR TITLE
Require set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dag (0.0.7)
+    dag (0.0.8)
 
 GEM
   remote: https://rubygems.org/

--- a/dag.gemspec
+++ b/dag.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'dag'
-  s.version     = '0.0.7'
+  s.version     = '0.0.8'
   s.date        = '2015-08-27'
   s.license     = 'MIT'
   s.summary     = 'Directed acyclic graphs'

--- a/lib/dag.rb
+++ b/lib/dag.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 require_relative 'dag/vertex'
 
 class DAG
@@ -89,4 +91,3 @@ class DAG
   end
 
 end
-

--- a/lib/dag/vertex.rb
+++ b/lib/dag/vertex.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 class DAG
 
   class Vertex
@@ -99,4 +101,3 @@ class DAG
   end
 
 end
-


### PR DESCRIPTION
The Set library isn't preloaded.

```
irb(main):001:0> require_relative 'lib/dag'
true
irb(main):002:0> dag = DAG.new
#<DAG:0x007fab161070c0 @vertices=[], @edges=[], @mixin=nil>
irb(main):003:0> v1 = dag.add_vertex
DAG::Vertex:{}
irb(main):004:0> v1.descendants
NameError: uninitialized constant DAG::Vertex::Set
```
